### PR TITLE
Run docs tests regularly against prod and staging

### DIFF
--- a/.github/workflows/docs_cron.yml
+++ b/.github/workflows/docs_cron.yml
@@ -1,12 +1,14 @@
 name: Test Code Examples
 
 on:
+  schedule:
+    # Run at 9am UTC daily
+    - cron: '0 9 * * *'
   workflow_dispatch:
-  pull_request:
 
 jobs:
-  test:
-    name: Check code examples in docs
+  test-staging:
+    name: Check code examples in docs against staging
     runs-on: ubuntu-latest
 
     steps:
@@ -23,10 +25,56 @@ jobs:
     - name: Run tests
       run: poetry run pytest
       env:
-        PORTIA_API_KEY: ${{ secrets.PORTIA_API_KEY }}
-        PORTIA_API_ENDPOINT: ${{ secrets.PORTIA_API_ENDPOINT }}
+        PORTIA_API_KEY: ${{ secrets.PORTIA_STAGING_API_KEY }}
+        PORTIA_API_ENDPOINT: ${{ secrets.PORTIA_STAGING_API_ENDPOINT }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
         OPENWEATHERMAP_API_KEY: ${{ secrets.OPENWEATHERMAP_API_KEY }}
         TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+
+
+    - name: Notify Slack on failure
+      if: failure()
+      uses: slackapi/slack-github-action@v1.27.0
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      with:
+        slack-message: "Docs testing against staging failed! See https://github.com/portiaAI/docs/actions/runs/${{ github.run_id }} for more details."
+        channel-id: C07V8NK09RC
+
+  test-production:
+    name: Check code examples in docs against production
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: production
+
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - name: Install dependencies
+      run: poetry install --no-interaction --all-extras
+
+    - name: Run tests
+      run: poetry run pytest
+      env:
+        PORTIA_API_KEY: ${{ secrets.PORTIA_API_KEY }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+        OPENWEATHERMAP_API_KEY: ${{ secrets.OPENWEATHERMAP_API_KEY }}
+        TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+
+    - name: Notify Slack on failure
+      if: failure()
+      uses: slackapi/slack-github-action@v1.27.0
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      with:
+        slack-message: "Docs testing against production failed! See https://github.com/portiaAI/docs/actions/runs/${{ github.run_id }} for more details."
+        channel-id: C07V8NK09RC

--- a/.github/workflows/docs_on_pr.yml
+++ b/.github/workflows/docs_on_pr.yml
@@ -1,10 +1,8 @@
 name: Test Code Examples
 
 on:
-  schedule:
-    # Run at 9am UTC daily
-    - cron: '0 9 * * *'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   test:
@@ -25,20 +23,10 @@ jobs:
     - name: Run tests
       run: poetry run pytest
       env:
-        PORTIA_API_KEY: ${{ secrets.PORTIA_API_KEY }}
-        PORTIA_API_ENDPOINT: ${{ secrets.PORTIA_API_ENDPOINT }}
+        PORTIA_API_KEY: ${{ secrets.PORTIA_STAGING_API_KEY }}
+        PORTIA_API_ENDPOINT: ${{ secrets.PORTIA_STAGING_API_ENDPOINT }}
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
         OPENWEATHERMAP_API_KEY: ${{ secrets.OPENWEATHERMAP_API_KEY }}
         TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
-
-
-    - name: Notify Slack on failure
-      if: failure() && github.ref == 'refs/heads/main'
-      uses: slackapi/slack-github-action@v1.27.0
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      with:
-        slack-message: "Docs testing failed! See https://github.com/portiaAI/docs/actions/runs/${{ github.run_id }} for more details."
-        channel-id: C07V8NK09RC


### PR DESCRIPTION
We will now regularly run docs tests from `main` against staging and from `production` against production.

Note - the diff is a little weird here because the files were named wrong previously.