### PR TITLE
Updated docs for "Manage your config" with new model config options

### DIFF
--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -206,7 +206,7 @@ class MyGenerativeModel(GenerativeModel):
         ...
 
 config = Config.from_default(
-    default_model=MyGenerativeModel()
+    default_model=MyGenerativeModel("my-model-name")
 )
 ```
 

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -63,8 +63,8 @@ The API keys for the LLM Providers can be set via `Config` class properties or e
 
 | Option | Values |
 | - | - |
-| Config property | `openai_api_key`, `anthropic_api_key`, `mistralai_api_key`, `google_generativeai_api_key`, `azure_openai_api_key` |
-| Environment variable | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY` |
+| Config property | `openai_api_key`<br/>`anthropic_api_key`<br/>`mistralai_api_key`<br/>`google_api_key`<br/>`azure_openai_api_key` |
+| Environment variable | `OPENAI_API_KEY`<br/>`ANTHROPIC_API_KEY`<br/>`MISTRAL_API_KEY`<br/>`GOOGLE_API_KEY`<br/>`AZURE_OPENAI_API_KEY` |
 
 
 #### Examples:

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -21,15 +21,15 @@ The `Config` class (<a href="/SDK/portia/config" target="_blank">**SDK reference
 
 ### LLM Provider
 
+This configures the API that Portia will use for LLM calls. If set, this decides which generative AI models are used in Portia defined Agents and Tools.
+
 |   |   |
 | - | - |
 | Config settings | `Config.llm_provider` |
-| Environment variables | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY` |
-| Values | `str`, `LLMProvider` |
+| Environment variables | `OPENAI_API_KEY`<br/>`ANTHROPIC_API_KEY`<br/>`MISTRALAI_API_KEY`<br/>`GOOGLE_GENERATIVEAI_API_KEY`<br/>`AZURE_OPENAI_API_KEY` |
+| Valid types | `str`<br/> `LLMProvider(Enum)` |
 
-If set, this decides what generative AI models are used in Portia defined Agents and Tools.
-
-This can be set using the `LLMProvider` or a string:
+The valid values for the `str` or `LLMProvider(Enum)` are:
 
 | LLMProvider | string |
 | ----------- | -------- |
@@ -38,6 +38,7 @@ This can be set using the `LLMProvider` or a string:
 | `LLMProvider.MISTRALAI` | `mistralai` |
 | `LLMProvider.GOOGLE_GENERATIVE_AI` | `google-generativeai` |
 | `LLMProvider.AZURE_OPENAI` | `azure-openai` |
+| `LLMProvider.OLLAMA` | `ollama` |
 
 :::tip[NB]
 If not provided, the LLM provider will be inferred from the environment variable.
@@ -50,14 +51,14 @@ Using enum:
 ```python
 from portia import LLMProvider, Config
 
-config = Config(llm_provider=LLMProvider.OPENAI)
+config = Config.from_default(llm_provider=LLMProvider.OPENAI)
 ```
 
 Using string:
 ```python
 from portia import LLMProvider, Config
 
-config = Config(llm_provider="anthropic")
+config = Config.from_default(llm_provider="anthropic")
 ```
 
 Via environment variable:
@@ -72,10 +73,12 @@ config = Config()
 
 ### Model overrides
 
+Specific models
+
 |   |   |
 | - | - |
-| Config settings | `default_model`, `planning_model`, `execution_model`, `introspection_model`, `summariser_model` |
-| Values | `str`, `GenerativeModel` |
+| Config settings | `default_model`<br/>`planning_model`<br/>`execution_model`<br/>`introspection_model`<br/>`summariser_model` |
+| Values | `str`<br/>`GenerativeModel` |
 
 Or
 
@@ -97,7 +100,7 @@ Using model string:
 ```python
 from portia import Config
 
-config = Config(default_model="openai/gpt-4o")
+config = Config.from_default(default_model="openai/gpt-4o")
 ```
 
 Using model instance:
@@ -106,7 +109,7 @@ from pydantic import SecretStr
 from portia import Config
 from portia.models import OpenAIGenerativeModel
 
-config = Config(default_model=OpenAIGenerativeModel(model_name="gpt-4o", api_key=SecretStr("sk-...")))
+config = Config.from_default(default_model=OpenAIGenerativeModel(model_name="gpt-4o", api_key=SecretStr("sk-...")))
 ```
 
 Using the `models` property:
@@ -115,7 +118,7 @@ from portia import Config
 from portia.models import OpenAIGenerativeModel
 
 # You can mix and match model strings and model instances
-config = Config(
+config = Config.from_default(
     models={
         "default_model": OpenAIGenerativeModel(model_name="gpt-4o", api_key=SecretStr("sk-...")),
         "planning_model": "anthropic/claude-3-5-sonnet",
@@ -163,7 +166,7 @@ Using environment variables:
 from pydantic import SecretStr
 from portia import Config
 
-config = Config(anthropic_api_key=SecretStr("sk-..."))
+config = Config.from_default(anthropic_api_key=SecretStr("sk-..."))
 ```
 
 ## Manage storage options

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -187,6 +187,7 @@ You can bring your own models to Portia by implementing the `GenerativeModel` in
 ```python
 from portia import Config, GenerativeModel, LLMProvider, Message
 from pydantic import BaseModel
+from langchain_core.language_models.chat_models import BaseChatModel
 
 class MyGenerativeModel(GenerativeModel):
     provider: LLMProvider = LLMProvider.CUSTOM

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -25,7 +25,7 @@ This configures the API that Portia will use for LLM calls. If set, this decides
 
 |   |   |
 | - | - |
-| Config settings | `Config.llm_provider` |
+| Config settings | `llm_provider` |
 | Environment variables | `OPENAI_API_KEY`<br/>`ANTHROPIC_API_KEY`<br/>`MISTRALAI_API_KEY`<br/>`GOOGLE_GENERATIVEAI_API_KEY`<br/>`AZURE_OPENAI_API_KEY` |
 | Valid types | `str`<br/> `LLMProvider(Enum)` |
 
@@ -79,14 +79,14 @@ Specific models
 |   |   |
 | - | - |
 | Config settings | `default_model` - The fallback default model for all use-cases if not specified elsewhere<br/>`planning_model` - The model used for the Planning Agent<br/>`execution_model` - The model used for the Execution Agent<br/>`introspection_model` - The model used for the Introspection Agent<br/>`summariser_model` - The model used for the Summariser Agent |
-| Values | `str`<br/>`GenerativeModel` |
+| Valid types | `str`<br/>`GenerativeModel` |
 
 Or
 
 |   |   |
 | - | - |
-| Config setting | `Config.models` |
-| Values | `dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
+| Config setting | `models` |
+| Valid types | `dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
 
 If set, this decides what generative AI model is used in Portia defined Agents and Tools. It will overwrite the default model for the LLM provider.
 
@@ -156,7 +156,7 @@ tool_regsitry = DefaultToolRegistry().replace_tool(new_llm_tool)
 | - | - |
 | Config settings | `openai_api_key`, `anthropic_api_key`, `mistralai_api_key`, `google_generativeai_api_key`, `azure_openai_api_key` |
 | Environment variables | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY` |
-| Values | `str` |
+| Valid types | `str` |
 
 The keys are used to authenticate with the LLM provider, via the `GenerativeModel` classes.
 

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -25,7 +25,7 @@ The `Config` class (<a href="/SDK/portia/config" target="_blank">**SDK reference
 | - | - |
 | Config settings | `Config.llm_provider` |
 | Environment variables | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY` |
-| Values | `str | LLMProvider` |
+| Values | `str`, `LLMProvider` |
 
 If set, this decides what generative AI models are used in Portia defined Agents and Tools.
 
@@ -46,13 +46,17 @@ For example, if `OPENAI_API_KEY` is found, the provider will be set to `LLMProvi
 
 ### Model overrides
 
-Config settings: `default_model`, `planning_model`, `execution_model`, `introspection_model`, `summariser_model`
-Values: `str | GenerativeModel`
+|   |   |
+| - | - |
+| Config settings | `default_model`, `planning_model`, `execution_model`, `introspection_model`, `summariser_model` |
+| Values | `str`, `GenerativeModel` |
 
 Or
 
-Config setting: `Config.models`
-Values: `dict[str, GenerativeModel | str]`
+|   |   |
+| - | - |
+| Config setting | `Config.models` |
+| Values | `dict[str, GenerativeModel | str]` |
 
 If set, this decides what generative AI model is used in Portia defined Agents and Tools. It will overwrite the default model for the LLM provider.
 
@@ -63,9 +67,11 @@ Examples: `openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `mistralai/mistral-lar
 
 ### API keys
 
-Config settings: `openai_api_key`, `anthropic_api_key`, `mistralai_api_key`, `google_generativeai_api_key`, `azure_openai_api_key`
-Environment variables: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY`
-Values: `str`
+|   |   |
+| - | - |
+| Config settings | `openai_api_key`, `anthropic_api_key`, `mistralai_api_key`, `google_generativeai_api_key`, `azure_openai_api_key` |
+| Environment variables | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY` |
+| Values | `str` |
 
 The keys are used to authenticate with the LLM provider, via the `GenerativeModel` classes.
 

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -115,6 +115,7 @@ config = Config.from_default(default_model=OpenAIGenerativeModel(model_name="gpt
 
 Using the `models` property:
 ```python
+from pydantic import SecretStr
 from portia import Config
 from portia.models import OpenAIGenerativeModel
 
@@ -143,6 +144,7 @@ portia = Portia(config=Config.from_default(), tools=tool_regsitry)
 Like other config options, you can also provide an explicit model instance to the tool constructor:
 
 ```python
+from pydantic import SecretStr
 from portia import LLMTool, DefaultToolRegistry
 from portia.models import OpenAIGenerativeModel
 
@@ -164,10 +166,9 @@ The keys are used to authenticate with the LLM provider, via the `GenerativeMode
 
 Using environment variables:
 ```python
-from pydantic import SecretStr
 from portia import Config
 
-config = Config.from_default(anthropic_api_key=SecretStr("sk-..."))
+config = Config.from_default(anthropic_api_key="sk-...")
 ```
 
 ## Manage storage options

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -21,7 +21,9 @@ The `Config` class (<a href="/SDK/portia/config" target="_blank">**SDK reference
 
 ### LLM Provider
 
-This configures the API that Portia will use for LLM calls. If set, this decides which generative AI models are used in Portia defined Agents and Tools.
+Portia uses providers such as OpenAI and Anthropic for usage of generative AI models. You can configure the provider that Portia will use with the `llm_provider` config setting.
+
+If set, this decides which generative AI models are used in Portia defined Agents and Tools. Portia has built-in defaults for which models to use for each provider, so at a minimum you only need to set this property.
 
 |   |   |
 | - | - |

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -78,15 +78,16 @@ Specific models
 
 |   |   |
 | - | - |
-| Config settings | `default_model` - The fallback default model for all use-cases if not specified elsewhere<br/>`planning_model` - The model used for the Planning Agent<br/>`execution_model` - The model used for the Execution Agent<br/>`introspection_model` - The model used for the Introspection Agent<br/>`summariser_model` - The model used for the Summariser Agent |
-| Valid types | `str`<br/>`GenerativeModel` |
+| Config setting | `models` |
+| Valid types | `GenerativeModels`<br/>`dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
 
 Or
 
 |   |   |
 | - | - |
-| Config setting | `models` |
-| Valid types | `dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
+| Config settings | `default_model` - The fallback default model for all use-cases if not specified elsewhere<br/>`planning_model` - The model used for the Planning Agent<br/>`execution_model` - The model used for the Execution Agent<br/>`introspection_model` - The model used for the Introspection Agent<br/>`summariser_model` - The model used for the Summariser Agent |
+| Valid types | `str`<br/>`GenerativeModel` |
+
 
 If set, this decides what generative AI model is used in Portia defined Agents and Tools. It will overwrite the default model for the LLM provider.
 
@@ -154,12 +155,13 @@ tool_regsitry = DefaultToolRegistry().replace_tool(new_llm_tool)
 
 ### API keys
 
+<center>
 |   |   |
 | - | - |
 | Config settings | `openai_api_key`, `anthropic_api_key`, `mistralai_api_key`, `google_generativeai_api_key`, `azure_openai_api_key` |
 | Environment variables | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY` |
 | Valid types | `str` |
-
+</center>
 The keys are used to authenticate with the LLM provider, via the `GenerativeModel` classes.
 
 #### Examples:

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -99,8 +99,13 @@ Or, if using `Config.from_default(...)`, you can specify the models using the fo
 If set, this decides what generative AI model is used in Portia defined Agents and Tools. It will overwrite the default model for the LLM provider.
 
 :::tip[Model string parsing]
-Model strings are in the format `provider/model_name`, where the `provider` is the string value of the LLM provider (e.g. `openai`) and the `model_name` is the name of the model you want to use.
-Examples: `openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `mistralai/mistral-large-latest`, `google-generativeai/gemini-1.5-flash`, `azure-openai/gpt-4o`
+Model strings are in the format `provider/model_name`, where the `provider` is the string value of the LLM provider (e.g. `openai`) and the `model_name` is the name of the model you want to use.<br/>
+Examples:
+- `openai/gpt-4o`
+- `anthropic/claude-3-5-sonnet`
+- `mistralai/mistral-large-latest`
+- `google-generativeai/gemini-1.5-flash`
+- `azure-openai/gpt-4o`
 :::
 
 #### Examples:

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -98,7 +98,7 @@ Or, if using `Config.from_default(...)`, you can specify the models using the fo
 
 If set, this decides what generative AI model is used in Portia defined Agents and Tools. It will overwrite the default model for the LLM provider.
 
-:::tip[Model string parsing]
+:::tip[Configuring models with model names]
 Model strings are in the format `provider/model_name`, where the `provider` is the string value of the LLM provider (e.g. `openai`) and the `model_name` is the name of the model you want to use.<br/>
 Examples:
 - `openai/gpt-4o`

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -27,7 +27,7 @@ This configures the API that Portia will use for LLM calls. If set, this decides
 | - | - |
 | Config settings | `llm_provider` |
 | Environment variables | `OPENAI_API_KEY`<br/>`ANTHROPIC_API_KEY`<br/>`MISTRALAI_API_KEY`<br/>`GOOGLE_GENERATIVEAI_API_KEY`<br/>`AZURE_OPENAI_API_KEY` |
-| Valid types | `str`<br/> `LLMProvider(Enum)` |
+| Valid types | `str` - see table below on valid strings<br/> `LLMProvider(Enum)` - see table below on valid values |
 
 The valid values for the `str` or `LLMProvider(Enum)` are:
 
@@ -79,14 +79,14 @@ Specific models
 |   |   |
 | - | - |
 | Config setting | `models` |
-| Valid types | `GenerativeModels`<br/>`dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
+| Valid types | `GenerativeModels` - Config class for specifying models for Portia Agents<br/>`dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
 
 Or
 
 |   |   |
 | - | - |
 | Config settings | `default_model` - The fallback default model for all use-cases if not specified elsewhere<br/>`planning_model` - The model used for the Planning Agent<br/>`execution_model` - The model used for the Execution Agent<br/>`introspection_model` - The model used for the Introspection Agent<br/>`summariser_model` - The model used for the Summariser Agent |
-| Valid types | `str`<br/>`GenerativeModel` |
+| Valid types | `str` - see note below on valid strings<br/>`GenerativeModel` - pass your own `GenerativeModel` instance |
 
 
 If set, this decides what generative AI model is used in Portia defined Agents and Tools. It will overwrite the default model for the LLM provider.
@@ -111,7 +111,12 @@ from pydantic import SecretStr
 from portia import Config
 from portia.models import OpenAIGenerativeModel
 
-config = Config.from_default(default_model=OpenAIGenerativeModel(model_name="gpt-4o", api_key=SecretStr("sk-...")))
+config = Config.from_default(
+    default_model=OpenAIGenerativeModel(
+        model_name="gpt-4o",
+        api_key=SecretStr("sk-..."),
+    )
+)
 ```
 
 Using the `models` property:
@@ -155,13 +160,12 @@ tool_regsitry = DefaultToolRegistry().replace_tool(new_llm_tool)
 
 ### API keys
 
-<center>
 |   |   |
 | - | - |
 | Config settings | `openai_api_key`, `anthropic_api_key`, `mistralai_api_key`, `google_generativeai_api_key`, `azure_openai_api_key` |
 | Environment variables | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY` |
 | Valid types | `str` |
-</center>
+
 The keys are used to authenticate with the LLM provider, via the `GenerativeModel` classes.
 
 #### Examples:

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -74,14 +74,21 @@ config.llm_provider is LLMProvider.OPENAI
 
 ### Model overrides
 
-Specific models
+You can configure Portia to use specific models for the different agents, overriding the default model for the LLM provider.
+
+You might do this if you want to:
+- Trade off cost against performance, for example using a cheaper model for the Planning Agent
+- Extend Portia to support an LLM provider that we do not natively support
+- Mix and match models from different providers, for example using OpenAI o3-mini for the Planning Agent and Anthropic Claude 3.7 Sonnet for everything else
+
+The relevant config settings are:
 
 |   |   |
 | - | - |
 | Config setting | `models` |
 | Valid types | `GenerativeModels` - Config class for specifying models for Portia Agents<br/>`dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
 
-Or
+Or, if using `Config.from_default(...)`, you can specify the models using the following arguments:
 
 |   |   |
 | - | - |

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -25,6 +25,7 @@ Portia uses providers such as OpenAI and Anthropic for usage of generative AI mo
 
 If set, this decides which generative AI models are used in Portia defined Agents and Tools. Portia has built-in defaults for which models to use for each provider, so at a minimum you only need to set this property.
 
+| Property | Value |
 | - | - |
 | Config settings | `llm_provider` |
 | Environment variables | `OPENAI_API_KEY`<br/>`ANTHROPIC_API_KEY`<br/>`MISTRALAI_API_KEY`<br/>`GOOGLE_GENERATIVEAI_API_KEY`<br/>`AZURE_OPENAI_API_KEY` |
@@ -82,14 +83,14 @@ You might do this if you want to:
 
 The relevant config settings are:
 
-|   |   |
+| Property | Value |
 | - | - |
 | Config setting | `models` |
 | Valid types | `GenerativeModelsConfig` - Config class for specifying models for Portia Agents<br/>`dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
 
 Or, if using `Config.from_default(...)`, you can specify the models using the following arguments:
 
-|   |   |
+| Property | Value |
 | - | - |
 | Config settings | `default_model` - The fallback default model for all use-cases if not specified elsewhere<br/>`planning_model` - The model used for the Planning Agent<br/>`execution_model` - The model used for the Execution Agent<br/>`introspection_model` - The model used for the Introspection Agent<br/>`summariser_model` - The model used for the Summariser Agent |
 | Valid types | `str` - see note below on valid strings<br/>`GenerativeModel` - pass your own `GenerativeModel` instance |
@@ -176,7 +177,7 @@ If you do not provide a model, the default model for the LLM provider will be us
 
 ### API keys
 
-|   |   |
+| Property | Value |
 | - | - |
 | Config settings | `openai_api_key`, `anthropic_api_key`, `mistralai_api_key`, `google_generativeai_api_key`, `azure_openai_api_key` |
 | Environment variables | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY` |

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -47,28 +47,29 @@ For example, if `OPENAI_API_KEY` is found, the provider will be set to `LLMProvi
 
 #### Examples:
 
-Using enum:
+Using the `LLMProvider` enum:
 ```python
 from portia import LLMProvider, Config
 
 config = Config.from_default(llm_provider=LLMProvider.OPENAI)
 ```
 
-Using string:
+Passing the string value:
 ```python
 from portia import LLMProvider, Config
 
 config = Config.from_default(llm_provider="anthropic")
 ```
 
-Via environment variable:
+Inferred from environment variables:
 ```python
 import os
 from portia import LLMProvider, Config
 
 os.environ["OPENAI_API_KEY"] = "sk-..."
 
-config = Config()
+config = Config.from_default()
+config.llm_provider is LLMProvider.OPENAI
 ```
 
 ### Model overrides
@@ -77,7 +78,7 @@ Specific models
 
 |   |   |
 | - | - |
-| Config settings | `default_model`<br/>`planning_model`<br/>`execution_model`<br/>`introspection_model`<br/>`summariser_model` |
+| Config settings | `default_model` - The fallback default model for all use-cases if not specified elsewhere<br/>`planning_model` - The model used for the Planning Agent<br/>`execution_model` - The model used for the Execution Agent<br/>`introspection_model` - The model used for the Introspection Agent<br/>`summariser_model` - The model used for the Summariser Agent |
 | Values | `str`<br/>`GenerativeModel` |
 
 Or
@@ -85,7 +86,7 @@ Or
 |   |   |
 | - | - |
 | Config setting | `Config.models` |
-| Values | `dict[str, GenerativeModel | str]` |
+| Values | `dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
 
 If set, this decides what generative AI model is used in Portia defined Agents and Tools. It will overwrite the default model for the LLM provider.
 

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -167,6 +167,8 @@ from portia import Config, GenerativeModel, LLMProvider, Message
 from pydantic import BaseModel
 from langchain_core.language_models.chat_models import BaseChatModel
 
+BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
+
 class MyGenerativeModel(GenerativeModel):
     provider: LLMProvider = LLMProvider.CUSTOM
 
@@ -176,8 +178,8 @@ class MyGenerativeModel(GenerativeModel):
     def get_structured_response(
         self,
         messages: list[Message],
-        schema: type[BaseModel],
-    ) -> BaseModel:
+        schema: type[BaseModelT],
+    ) -> BaseModelT:
         """Requires implementation"""
 
     def to_langchain(self) -> BaseChatModel:

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -185,10 +185,24 @@ If you do not provide a model, the default model for the LLM provider will be us
 You can bring your own models to Portia by implementing the `GenerativeModel` interface and passing an instance of your class to the `Config` class.
 
 ```python
-from portia import Config, GenerativeModel
+from portia import Config, GenerativeModel, LLMProvider, Message
+from pydantic import BaseModel
 
 class MyGenerativeModel(GenerativeModel):
-    ... # Implement the GenerativeModel interface
+    provider: LLMProvider = LLMProvider.CUSTOM
+
+    def get_response(self, messages: list[Message]) -> Message:
+        ...
+
+    def get_structured_response(
+        self,
+        messages: list[Message],
+        schema: type[BaseModel],
+    ) -> BaseModel:
+        ...
+
+    def to_langchain(self) -> BaseChatModel:
+        ...
 
 config = Config.from_default(
     default_model=MyGenerativeModel()
@@ -198,7 +212,7 @@ config = Config.from_default(
 In this case you do **not** need to set the `llm_provider` config setting, or provide any API keys.
 
 :::tip[NB]
-Currently Portia relies on LangChain BaseChatModel clients in several places, so we are limited to the models that LangChain supports.<br/>
+Currently Portia relies on LangChain `BaseChatModel` clients in several places, so we are limited to the models that LangChain supports.<br/>
 Thankfully, this is a very <a href="https://python.langchain.com/docs/integrations/providers/" target="_blank">broad set of models</a>, so there is a good chance that your model of choice is supported.
 :::
 

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -96,7 +96,7 @@ You can configure each of these models in the following ways:
 
 | Option | Value |
 | - | - |
-| Model name (`str`) | A `str` in the form `provider/model_name`, for example `openai/gpt-4o`. See tip below for more examples. |
+| Model name (`str`) | A `str` in the form `provider/model_name`, for example `openai/gpt-4.1`. See tip below for more examples. |
 | Model object (`GenerativeModel`) | An instance of a `GenerativeModel` class. See [Bring your own models](#bring-your-own-models) below for more details. |
 
 Alternatively, if setting the models directly in the `Config` class, you should use the `models` property, which is a `GenerativeModelsConfig` instance. See the example below for more details.
@@ -104,7 +104,7 @@ Alternatively, if setting the models directly in the `Config` class, you should 
 :::tip[Configuring models with model names]
 Model strings are in the format `provider/model_name`, where the `provider` is the string value of the LLM provider (e.g. `openai`) and the `model_name` is the name of the model you want to use.<br/>
 Examples:
-- `openai/gpt-4o`
+- `openai/gpt-4.1`
 - `anthropic/claude-3-5-sonnet`
 - `mistralai/mistral-large-latest`
 - `google-generativeai/gemini-1.5-flash`
@@ -117,7 +117,7 @@ Setting the default model by its name:
 ```python
 from portia import Config
 
-config = Config.from_default(default_model="openai/gpt-4o")
+config = Config.from_default(default_model="openai/gpt-4.1")
 ```
 
 Mixing and matching models from different providers. Make sure that the relevant API keys are set in the environment variables, or passed along with the model name:
@@ -125,7 +125,7 @@ Mixing and matching models from different providers. Make sure that the relevant
 ```python
 from portia import Config
 
-config = Config.from_default(default_model="openai/gpt-4o", planning_model="anthropic/claude-3-5-sonnet")
+config = Config.from_default(default_model="openai/gpt-4.1", planning_model="anthropic/claude-3-5-sonnet")
 ```
 
 
@@ -160,7 +160,7 @@ If you do not provide a model, the default model for the LLM provider will be us
 
 ### Bring your own models
 
-You can bring your own models to Portia by implementing the `GenerativeModel` (<a href="/SDK/portia/model#generativemodel-objects" target="_blank">**SDK reference ↗**</a>) interface and passing an instance of your class to the `Config` class.
+You can bring your own models to Portia by implementing the `GenerativeModel` base class (<a href="/SDK/portia/model#generativemodel-objects" target="_blank">**SDK reference ↗**</a>) and passing an instance of your class to the `Config` class.
 
 ```python
 from portia import Config, GenerativeModel, LLMProvider, Message

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -131,7 +131,12 @@ config = Config.from_default(default_model="openai/gpt-4o", planning_model="anth
 
 ### Models for Tools
 
-Some tools provided by the SDK are LLM-based. You can control the model used by these tools by passing a `model` directly to the tool constructor:
+A couple of the tools provided in the Portia SDK use generative models to complete tasks, specifically:
+
+- `LLMTool` (<a href="/SDK/portia/open_source_tools/llm_tool" target="_blank">**SDK reference ↗**</a>)
+- `ImageUnderstandingTool` (<a href="/SDK/portia/open_source_tools/image_understanding_tool" target="_blank">**SDK reference ↗**</a>)
+
+You can replace the tool in the `DefaultToolRegistry` with your own instance of the tool that uses a different model by passing a `model` directly to the tool constructor:
 
 ```python
 import dotenv
@@ -149,7 +154,9 @@ tool_registry = DefaultToolRegistry(config).replace_tool(
 portia = Portia(config=config, tools=tool_registry)
 ```
 
+:::tip[NB]
 If you do not provide a model, the default model for the LLM provider will be used.
+:::
 
 ### Bring your own models
 

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -25,7 +25,6 @@ Portia uses providers such as OpenAI and Anthropic for usage of generative AI mo
 
 If set, this decides which generative AI models are used in Portia defined Agents and Tools. Portia has built-in defaults for which models to use for each provider, so at a minimum you only need to set this property.
 
-|   |   |
 | - | - |
 | Config settings | `llm_provider` |
 | Environment variables | `OPENAI_API_KEY`<br/>`ANTHROPIC_API_KEY`<br/>`MISTRALAI_API_KEY`<br/>`GOOGLE_GENERATIVEAI_API_KEY`<br/>`AZURE_OPENAI_API_KEY` |
@@ -44,7 +43,8 @@ The valid values for the `str` or `LLMProvider(Enum)` are:
 
 :::tip[NB]
 If not provided, the LLM provider will be inferred from the environment variable.
-For example, if `OPENAI_API_KEY` is found, the provider will be set to `LLMProvider.OPENAI`
+For example, if `OPENAI_API_KEY` is found, the provider will be set to `LLMProvider.OPENAI`.
+If you have multiple provider keys in your environment, make sure you set your preferred provider using the `llm_provider` config setting.
 :::
 
 #### Examples:
@@ -85,7 +85,7 @@ The relevant config settings are:
 |   |   |
 | - | - |
 | Config setting | `models` |
-| Valid types | `GenerativeModels` - Config class for specifying models for Portia Agents<br/>`dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
+| Valid types | `GenerativeModelsConfig` - Config class for specifying models for Portia Agents<br/>`dict[str, GenerativeModel \| str]` - Mapping from model key to model instance or string |
 
 Or, if using `Config.from_default(...)`, you can specify the models using the following arguments:
 
@@ -132,19 +132,18 @@ Using the `models` property:
 ```python
 import dotenv
 from pydantic import SecretStr
-from portia import Config
-from portia.config import GenerativeModels
+from portia import Config, GenerativeModelsConfig
 from portia.model import OpenAIGenerativeModel
 
 dotenv.load_dotenv()
 
 # You can mix and match model strings and model instances
 config = Config.from_default(
-    models=GenerativeModels(
+    models=GenerativeModelsConfig(
         default_model=OpenAIGenerativeModel(model_name="gpt-4o", api_key=SecretStr("sk-...")),
         planning_model="anthropic/claude-3-5-sonnet",
-        summarizer_model="azure-openai/gpt-4o",
-    )
+        summarizer_model="google/gemini-2.0-flash",
+    ),
 )
 ```
 
@@ -161,16 +160,16 @@ dotenv.load_dotenv()
 
 config = Config.from_default()
 
-tool_regsitry = DefaultToolRegistry(config).replace_tool(
+tool_registry = DefaultToolRegistry(config).replace_tool(
     LLMTool(
         model=OpenAIGenerativeModel(
             model_name="gpt-4o",
-            api_key=config.must_get_api_key("openai")
+            api_key=config.must_get_api_key("openai_api_key")
         ),
     )
 )
 
-portia = Portia(config=config, tools=tool_regsitry)
+portia = Portia(config=config, tools=tool_registry)
 ```
 
 If you do not provide a model, the default model for the LLM provider will be used.

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -97,7 +97,7 @@ You can configure each of these models in the following ways:
 | Option | Value |
 | - | - |
 | Model name (`str`) | A `str` in the form `provider/model_name`, for example `openai/gpt-4.1`. See tip below for more examples. |
-| Model object (`GenerativeModel`) | An instance of a `GenerativeModel` class. See [Bring your own models](#bring-your-own-models) below for more details. |
+| Model object (`GenerativeModel`) | An instance of a `GenerativeModel` class. See the <u>[Bring your own models](#bring-your-own-models)</u> section below for more details. |
 
 Alternatively, if setting the models directly in the `Config` class, you should use the `models` property, which is a `GenerativeModelsConfig` instance. See the example below for more details.
 

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -163,6 +163,7 @@ If you do not provide a model, the default model for the LLM provider will be us
 You can bring your own models to Portia by implementing the `GenerativeModel` base class (<a href="/SDK/portia/model#generativemodel-objects" target="_blank">**SDK reference ↗**</a>) and passing an instance of your class to the `Config` class.
 
 ```python
+from typing import TypeVar
 from portia import Config, GenerativeModel, LLMProvider, Message
 from pydantic import BaseModel
 from langchain_core.language_models.chat_models import BaseChatModel

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -30,8 +30,8 @@ Options for setting the LLM provider are:
 | Option | Values |
 | - | - |
 | `LLMProvider` enum | `LLMProvider.OPENAI`<br/>`LLMProvider.ANTHROPIC`<br/>`LLMProvider.MISTRALAI`<br/>`LLMProvider.GOOGLE_GENERATIVE_AI`<br/>`LLMProvider.AZURE_OPENAI`<br/>`LLMProvider.OLLAMA` |
-| Provider name | `"openai"`<br/>`"anthropic"`<br/>`"mistralai"`<br/>`"google-generativeai"`<br/>`"azure-openai"`<br/>`"ollama"` |
-| Inferred from environment variable | `OPENAI_API_KEY`<br/>`ANTHROPIC_API_KEY`<br/>`MISTRALAI_API_KEY`<br/>`GOOGLE_GENERATIVEAI_API_KEY`<br/>`AZURE_OPENAI_API_KEY` |
+| Provider name (`str`) | `"openai"`<br/>`"anthropic"`<br/>`"mistralai"`<br/>`"google-generativeai"`<br/>`"azure-openai"`<br/>`"ollama"` |
+| Inferred from environment variable | `OPENAI_API_KEY`<br/>`ANTHROPIC_API_KEY`<br/>`MISTRAL_API_KEY`<br/>`GOOGLE_API_KEY`<br/>`AZURE_OPENAI_API_KEY` |
 
 
 #### Examples:
@@ -96,8 +96,8 @@ You can configure each of these models in the following ways:
 
 | Option | Value |
 | - | - |
-| Model name | A `str` in the form `provider/model_name`, for example `openai/gpt-4o`. See tip below for more examples. |
-| GenerativeModel | An instance of a `GenerativeModel` class. See [Bring your own models](#bring-your-own-models) below for more details. |
+| Model name (`str`) | A `str` in the form `provider/model_name`, for example `openai/gpt-4o`. See tip below for more examples. |
+| Model object (`GenerativeModel`) | An instance of a `GenerativeModel` class. See [Bring your own models](#bring-your-own-models) below for more details. |
 
 Alternatively, if setting the models directly in the `Config` class, you should use the `models` property, which is a `GenerativeModelsConfig` instance. See the example below for more details.
 
@@ -143,12 +143,7 @@ dotenv.load_dotenv()
 config = Config.from_default()
 
 tool_registry = DefaultToolRegistry(config).replace_tool(
-    LLMTool(
-        model=OpenAIGenerativeModel(
-            model_name="gpt-4o",
-            api_key=config.must_get_api_key("openai_api_key")
-        ),
-    )
+    LLMTool(model="openai/gpt-4.1-mini")
 )
 
 portia = Portia(config=config, tools=tool_registry)

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -44,7 +44,7 @@ If not provided, the LLM provider will be inferred from the environment variable
 For example, if `OPENAI_API_KEY` is found, the provider will be set to `LLMProvider.OPENAI`
 :::
 
-Examples:
+#### Examples:
 
 Using enum:
 ```python
@@ -114,6 +114,7 @@ Using the `models` property:
 from portia import Config
 from portia.models import OpenAIGenerativeModel
 
+# You can mix and match model strings and model instances
 config = Config(
     models={
         "default_model": OpenAIGenerativeModel(model_name="gpt-4o", api_key=SecretStr("sk-...")),

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -124,6 +124,28 @@ config = Config(
 )
 ```
 
+### Models for Tools
+
+Some tools provided by the SDK are LLM-based. You can control the model used by these tools by passing a `model` directly to the tool constructor:
+
+```python
+from portia import LLMTool, DefaultToolRegistry
+
+tool_regsitry = DefaultToolRegistry().replace_tool(LLMTool(model="openai/gpt-4o"))
+
+portia = Portia(config=Config.from_default(), tools=tool_regsitry)
+```
+
+Like other config options, you can also provide an explicit model instance to the tool constructor:
+
+```python
+from portia import LLMTool, DefaultToolRegistry
+from portia.models import OpenAIGenerativeModel
+
+new_llm_tool = LLMTool(model=OpenAIGenerativeModel(model_name="gpt-4o", api_key=SecretStr("sk-...")))
+tool_regsitry = DefaultToolRegistry().replace_tool(new_llm_tool)
+```
+
 ### API keys
 
 |   |   |

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -21,9 +21,11 @@ The `Config` class (<a href="/SDK/portia/config" target="_blank">**SDK reference
 
 ### LLM Provider
 
-Config settings: `Config.llm_provider`
-Environment variables: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY`
-Values: `str | LLMProvider`
+|   |   |
+| - | - |
+| Config settings | `Config.llm_provider` |
+| Environment variables | `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY` |
+| Values | `str | LLMProvider` |
 
 If set, this decides what generative AI models are used in Portia defined Agents and Tools.
 

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -180,6 +180,29 @@ portia = Portia(config=config, tools=tool_registry)
 
 If you do not provide a model, the default model for the LLM provider will be used.
 
+### Bring your own models
+
+You can bring your own models to Portia by implementing the `GenerativeModel` interface and passing an instance of your class to the `Config` class.
+
+```python
+from portia import Config, GenerativeModel
+
+class MyGenerativeModel(GenerativeModel):
+    ... # Implement the GenerativeModel interface
+
+config = Config.from_default(
+    default_model=MyGenerativeModel()
+)
+```
+
+In this case you do **not** need to set the `llm_provider` config setting, or provide any API keys.
+
+:::tip[NB]
+Currently Portia relies on LangChain BaseChatModel clients in several places, so we are limited to the models that LangChain supports.<br/>
+Thankfully, this is a very <a href="https://python.langchain.com/docs/integrations/providers/" target="_blank">broad set of models</a>, so there is a good chance that your model of choice is supported.
+:::
+
+
 ### API keys
 
 | Property | Value |

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -99,7 +99,7 @@ You can configure each of these models in the following ways:
 | Model name (`str`) | A `str` in the form `provider/model_name`, for example `openai/gpt-4.1`. See tip below for more examples. |
 | Model object (`GenerativeModel`) | An instance of a `GenerativeModel` class. See the <u>[Bring your own models](#bring-your-own-models)</u> section below for more details. |
 
-Alternatively, if setting the models directly in the `Config` class, you should use the `models` property, which is a `GenerativeModelsConfig` instance. See the example below for more details.
+Alternatively, if setting the models directly in the `Config` class, you should use the `models` property, which is a `GenerativeModelsConfig` object (<a href="/SDK/portia/config#generativemodelsconfig-objects" target="_blank">**SDK reference ↗**</a>). See the example below for more details.
 
 :::tip[Configuring models with model names]
 Model strings are in the format `provider/model_name`, where the `provider` is the string value of the LLM provider (e.g. `openai`) and the `model_name` is the name of the model you want to use.<br/>

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -18,17 +18,66 @@ The `Config` class of your `Portia` instance allows you to:
 
 ## Configure LLM options
 The `Config` class (<a href="/SDK/portia/config" target="_blank">**SDK reference ↗**</a>) allows you to control various LLM and agent execution options.
-| Property | Purpose |
-| ----------- | ----------- |
-| `llm_provider` | Select between `OPENAI`, `ANTHROPIC` OR `MISTRALAI`. <br/>This is an ENUM accessible from the `LLMProvider` class. |
-| `llm_model_name` | Select the relevant LLM model. This is an ENUM accessible via the `LLMModel` class. |
-| `openai_api_key`<br/>`anthropic_api_key`<br/>`mistralai_api_key` | Set the key you want your `Portia` instance instance to use from the relevant provider |
+
+### LLM Provider
+
+Config settings: `Config.llm_provider`
+Environment variables: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY`
+Values: `str | LLMProvider`
+
+If set, this decides what generative AI models are used in Portia defined Agents and Tools.
+
+This can be set using the `LLMProvider` or a string:
+
+| LLMProvider | string |
+| ----------- | -------- |
+| `LLMProvider.OPENAI` | `openai` |
+| `LLMProvider.ANTHROPIC` | `anthropic` |
+| `LLMProvider.MISTRALAI` | `mistralai` |
+| `LLMProvider.GOOGLE_GENERATIVE_AI` | `google-generativeai` |
+| `LLMProvider.AZURE_OPENAI` | `azure-openai` |
+
+:::tip[NB]
+If not provided, the LLM provider will be inferred from the environment variable.
+For example, if `OPENAI_API_KEY` is found, the provider will be set to `LLMProvider.OPENAI`
+:::
+
+### Model overrides
+
+Config settings: `default_model`, `planning_model`, `execution_model`, `introspection_model`, `summariser_model`
+Values: `str | GenerativeModel`
+
+Or
+
+Config setting: `Config.models`
+Values: `dict[str, GenerativeModel | str]`
+
+If set, this decides what generative AI model is used in Portia defined Agents and Tools. It will overwrite the default model for the LLM provider.
+
+:::tip[Model string parsing]
+Model strings are in the format `provider/model_name`, where the `provider` is the string value of the LLM provider (e.g. `openai`) and the `model_name` is the name of the model you want to use.
+Examples: `openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `mistralai/mistral-large-latest`, `google-generativeai/gemini-1.5-flash`, `azure-openai/gpt-4o`
+:::
+
+### API keys
+
+Config settings: `openai_api_key`, `anthropic_api_key`, `mistralai_api_key`, `google_generativeai_api_key`, `azure_openai_api_key`
+Environment variables: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `MISTRALAI_API_KEY`, `GOOGLE_GENERATIVEAI_API_KEY`, `AZURE_OPENAI_API_KEY`
+Values: `str`
+
+The keys are used to authenticate with the LLM provider, via the `GenerativeModel` classes.
 
 ## Manage storage options
 You can control where you store and retrieve plan run states using the `storage_class` property in the `Config` class (<a href="/SDK/portia/config" target="_blank">**SDK reference ↗**</a>), which is an ENUM accessible from the `StorageClass` class:
 - `MEMORY` allows you to use working memory (default if PORTIA_API_KEY is not specified).
 - `DISK` allows you to use local storage. You will need to set the `storage_dir` appropriately (defaults to the project's root directory).
 - `CLOUD` uses the Portia cloud (<a href="/store-retrieve-plan-runs" target="_blank">**Use Portia cloud ↗**</a> - default if PORTIA_API_KEY is specified).
+
+## Other config settings
+
+| Property | Purpose |
+| ----------- | ----------- |
+| `planner_system_context_extension` | Enrich the system context with more information. For example you can add information specific to a frontend user session such as department, title, timezone etc. |
 
 ## Manage logging
 You can control logging behaviour with the following `Config` properties (<a href="/SDK/portia/config" target="_blank">**SDK reference ↗**</a>):
@@ -66,7 +115,7 @@ my_config = Config.from_default(
     storage_class=StorageClass.DISK, 
     storage_dir='demo_runs', # Amend this based on where you'd like your plans and plan runs saved!
     default_log_level=LogLevel.DEBUG,
-    )
+)
 
 # Instantiate a Portia instance. Load it with the default config and with some example tools
 portia = Portia(config=my_config, tools=example_tool_registry)

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -44,6 +44,32 @@ If not provided, the LLM provider will be inferred from the environment variable
 For example, if `OPENAI_API_KEY` is found, the provider will be set to `LLMProvider.OPENAI`
 :::
 
+Examples:
+
+Using enum:
+```python
+from portia import LLMProvider, Config
+
+config = Config(llm_provider=LLMProvider.OPENAI)
+```
+
+Using string:
+```python
+from portia import LLMProvider, Config
+
+config = Config(llm_provider="anthropic")
+```
+
+Via environment variable:
+```python
+import os
+from portia import LLMProvider, Config
+
+os.environ["OPENAI_API_KEY"] = "sk-..."
+
+config = Config()
+```
+
 ### Model overrides
 
 |   |   |
@@ -65,6 +91,38 @@ Model strings are in the format `provider/model_name`, where the `provider` is t
 Examples: `openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `mistralai/mistral-large-latest`, `google-generativeai/gemini-1.5-flash`, `azure-openai/gpt-4o`
 :::
 
+#### Examples:
+
+Using model string:
+```python
+from portia import Config
+
+config = Config(default_model="openai/gpt-4o")
+```
+
+Using model instance:
+```python
+from pydantic import SecretStr
+from portia import Config
+from portia.models import OpenAIGenerativeModel
+
+config = Config(default_model=OpenAIGenerativeModel(model_name="gpt-4o", api_key=SecretStr("sk-...")))
+```
+
+Using the `models` property:
+```python
+from portia import Config
+from portia.models import OpenAIGenerativeModel
+
+config = Config(
+    models={
+        "default_model": OpenAIGenerativeModel(model_name="gpt-4o", api_key=SecretStr("sk-...")),
+        "planning_model": "anthropic/claude-3-5-sonnet",
+        "summariser_model": "azure-openai/gpt-4o",
+    }
+)
+```
+
 ### API keys
 
 |   |   |
@@ -74,6 +132,16 @@ Examples: `openai/gpt-4o`, `anthropic/claude-3-5-sonnet`, `mistralai/mistral-lar
 | Values | `str` |
 
 The keys are used to authenticate with the LLM provider, via the `GenerativeModel` classes.
+
+#### Examples:
+
+Using environment variables:
+```python
+from pydantic import SecretStr
+from portia import Config
+
+config = Config(anthropic_api_key=SecretStr("sk-..."))
+```
 
 ## Manage storage options
 You can control where you store and retrieve plan run states using the `storage_class` property in the `Config` class (<a href="/SDK/portia/config" target="_blank">**SDK reference ↗**</a>), which is an ENUM accessible from the `StorageClass` class:

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -81,9 +81,9 @@ config = Config.from_default(anthropic_api_key="sk-...")
 You can configure Portia to use specific models for different components, overriding the default model for the LLM provider.
 
 You might do this if you want to:
-- Trade off cost against performance, for example using a cheaper model for the Planning Agent
+- Trade off cost against performance, for example using a cheaper model for planning
 - Extend Portia to support an LLM provider that we do not natively support
-- Mix and match models from different providers, for example using OpenAI o3-mini for the Planning Agent and Anthropic Claude 3.7 Sonnet for everything else
+- Mix and match models from different providers, for example using OpenAI o3-mini for planning and Anthropic Claude 3.7 Sonnet for everything else
 
 The preferred way to do this is via the `Config.from_default(...)` method, which allows you to specify the models using the following arguments:
 - `default_model` - The fallback default model for all use-cases if not specified elsewhere

--- a/docs/product/Get started/install.md
+++ b/docs/product/Get started/install.md
@@ -164,7 +164,6 @@ As a final verification step for your installation, set up the required environm
         from dotenv import load_dotenv
         from portia import (
             Config,
-            LLMModel,
             LLMProvider,
             Portia,
             example_tool_registry,
@@ -176,9 +175,9 @@ As a final verification step for your installation, set up the required environm
         # Create a default Portia config with LLM provider set to Anthropic and to the Sonnet 3.5 model
         anthropic_config = Config.from_default(
             llm_provider=LLMProvider.ANTHROPIC,
-            llm_model_name=LLMModel.CLAUDE_3_5_SONNET,
+            default_model="anthropic/claude-3-5-sonnet-latest",
             anthropic_api_key=ANTHROPIC_API_KEY
-            )
+        )
         # Instantiate a Portia instance. Load it with the config and with the example tools.
         portia = Portia(config=anthropic_config, tools=example_tool_registry)
         # Run the test query and print the output!
@@ -194,7 +193,6 @@ As a final verification step for your installation, set up the required environm
         from dotenv import load_dotenv
         from portia import (
             Config,
-            LLMModel,
             LLMProvider,
             Portia,
             example_tool_registry,
@@ -206,7 +204,7 @@ As a final verification step for your installation, set up the required environm
         # Create a default Portia config with LLM provider set to Mistral AI and the latest Mistral Large model
         mistral_config = Config.from_default(
             llm_provider=LLMProvider.MISTRALAI,
-            llm_model_name=LLMModel.MISTRAL_LARGE,
+            default_model="mistralai/mistral-large-latest",
             mistralai_api_key=MISTRAL_API_KEY
         )
         # Instantiate a Portia instance. Load it with the config and with the example tools.
@@ -224,7 +222,6 @@ As a final verification step for your installation, set up the required environm
         from dotenv import load_dotenv
         from portia import (
             Config,
-            LLMModel,
             LLMProvider,
             Portia,
             example_tool_registry,
@@ -236,7 +233,7 @@ As a final verification step for your installation, set up the required environm
         # Create a default Portia config with LLM provider set to Google GenAI and model set to Gemini 2.0 Flash
         google_config = Config.from_default(
             llm_provider=LLMProvider.GOOGLE_GENERATIVE_AI,
-            llm_model_name=LLMModel.GEMINI_2_0_FLASH,
+            default_model="google/gemini-2.0-flash",
             google_api_key=GOOGLE_API_KEY
         )
         # Instantiate a Portia instance. Load it with the config and with the example tools.
@@ -254,7 +251,6 @@ As a final verification step for your installation, set up the required environm
         from dotenv import load_dotenv
         from portia import (
             Config,
-            LLMModel,
             LLMProvider,
             Portia,
             example_tool_registry,
@@ -267,7 +263,7 @@ As a final verification step for your installation, set up the required environm
         # Create a default Portia config with LLM provider set to Azure OpenAI and model to GPT 4o
         azure_config = Config.from_default(
             llm_provider=LLMProvider.AZURE_OPENAI,
-            llm_model_name=LLMModel.AZURE_GTP_4O,
+            default_model="azure-openai/gpt-4o",
             azure_openai_api_key=AZURE_OPENAI_API_KEY,
             azure_openai_endpoint=AZURE_OPENAI_ENDPOINT,
         )

--- a/docs/product/Get started/install.md
+++ b/docs/product/Get started/install.md
@@ -34,6 +34,10 @@ pip install portia-sdk-python[mistral]
 ### Configure access to your preferred LLM
 Set environment variables to connect to one of our currently supported LLMs. We are currently expanding this list. 
 
+:::tip[Configuring Portia]
+See <a href="/manage-config#configure-llm-options" target="_blank">**Configure LLM options ↗**</a> for more information on how to configure Portia for different LLM providers and models.
+:::
+
 <Tabs groupId="llm-provider">
     <TabItem value="openai" label="Open AI" default>
     `gpt-4o` is set as the default model. You can sign up to their platform **[here](https://platform.openai.com/signup)**

--- a/docs/product/Handle auth and clarifications/Understand clarifications.md
+++ b/docs/product/Handle auth and clarifications/Understand clarifications.md
@@ -170,7 +170,7 @@ while plan_run.state == PlanRunState.NEED_CLARIFICATION:
         plan_run = portia.resolve_clarification(clarification, user_input, plan_run)
 
     # Once clarifications are resolved, resume the plan run
-    plan_run = portia.run(plan_run)
+    plan_run = portia.resume(plan_run)
 # highlight-end
 
 # Serialise into JSON and print the output

--- a/docs/product/Plan and run workflows/Generate a plan.md
+++ b/docs/product/Plan and run workflows/Generate a plan.md
@@ -80,7 +80,7 @@ A plan includes a series of steps defined by
 - `"input"` The inputs required to achieve the step. Notice how the LLM is guided to weave the outputs of previous steps as inputs to the next ones where applicable e.g. `$spacex_news_results` coming out of the first step acts as an input to the second one.
 - `"tool_id"` Any relevant tool needed for the completion of the step. Portia is able to filter for the relevant tools during the multi-shot plan generation process. As we will see later on in this tutorial you can specify the tool registries (directories) you want when handling a user prompt, including local / custom tools and ones provided by third parties. In this example we are referencing tools from Portia's cloud-hosted library, prefixed with `portia:`. 
 - `"output"` The step's final output. As mentioned above, every step output can be referenced in future steps. As we will see shortly, these outputs are serialised and saved in plan run state as it is being executed.
-- `"condition"` An optional condition that's used to control the execution of the step. If the condition is not met, the step will be skipped.
+- `"condition"` An optional condition that's used to control the execution of the step. If the condition is not met, the step will be skipped. This condition will be evaluated by our introspection agent, with the context of the plan and plan run state.
 
 
 ## Create a plan from a user prompt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = ">=3.11,<3.14"
 pytest-examples = "^0.0.15"
-portia-sdk-python = {version = "^0.1.10", extras = ["all"]}
+portia-sdk-python = {version = "^0.2.0", extras = ["all"]}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
* More comprehensive documentation for model configuration
* We can add a link to the locally-running Portia example to demonstrate how to define your own models when that is merged
* Fix an issue found at Hackathon with clarifications

> [!NOTE]
> The tests are failing because the code is not yet in an alpha release 