### PR TITLE
pip install docs fix + subscription upgrade tip

### DIFF
--- a/docs/product/Get started/Set up your account.md
+++ b/docs/product/Get started/Set up your account.md
@@ -21,5 +21,6 @@ By default, Portia will look for the API key in the `PORTIA_API_KEY` environment
 export PORTIA_API_KEY='your-api-key-here'
 ``` 
 
-
-
+:::tip[Upgrading your account]
+You can upgrade your account to a Pro plan to increase your Portia tool and plan run usage limits. Head over to the <a href="https://app.portialabs.ai/dashboard/billing" target="_blank">**Billing page ↗**</a> to upgrade or manage your current plan.
+:::

--- a/docs/product/Get started/install.md
+++ b/docs/product/Get started/install.md
@@ -23,11 +23,11 @@ pip install portia-sdk-python
 ```
 Out of the box the SDK comes with dependencies for OpenAI (and Azure OpenAI) + Anthropic. We additionally support Mistral and Google GenAI (Gemini). These dependencies can be added with:
 ```bash
-pip install portia-sdk-python[all]
+pip install "portia-sdk-python[all]"
 # Or only Google GenAI
-pip install portia-sdk-python[google]
+pip install "portia-sdk-python[google]"
 # Or only Mistral
-pip install portia-sdk-python[mistral]
+pip install "portia-sdk-python[mistral]"
 ```
 
 
@@ -54,7 +54,7 @@ See <a href="/manage-config#configure-llm-options" target="_blank">**Configure L
     <TabItem value="mistral" label="Mistral">
     `mistral-large-latest` is set as the default model. You can sign up to their platform **[here](https://auth.mistral.ai/ui/registration)**
 
-    Ensure Mistral dependencies are installed with `pip install portia-sdk-python[mistral]` or `portia-sdk-python[all]`
+    Ensure Mistral dependencies are installed with `pip install "portia-sdk-python[mistral]"` or `"portia-sdk-python[all]"`
 
     ```bash
     export MISTRAL_API_KEY='your-api-key-here'
@@ -63,7 +63,7 @@ See <a href="/manage-config#configure-llm-options" target="_blank">**Configure L
     <TabItem value="google" label="Google GenAI">
     `gemini-flash-2.0` is set as the default model. You can sign up to their platform **[here](https://ai.google.dev/)**
 
-    Ensure Mistral dependencies are installed with `pip install portia-sdk-python[google]` or `portia-sdk-python[all]`
+    Ensure Mistral dependencies are installed with `pip install "portia-sdk-python[google]"` or `"portia-sdk-python[all]"`
 
     ```bash
     export GOOGLE_API_KEY='your-api-key-here'


### PR DESCRIPTION
https://linear.app/portialabs/issue/POR-1239/docs-pip-install-portia-sdk-python[all]
https://linear.app/portialabs/issue/POR-1286/add-docs-section-on-upgrading-to-paid-tier