### PR TITLE
Improve the naming of github actions

### DIFF
--- a/.github/workflows/docs_cron.yml
+++ b/.github/workflows/docs_cron.yml
@@ -1,4 +1,4 @@
-name: Test Code Examples
+name: Daily Test Code Examples
 
 on:
   schedule:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-staging:
-    name: Check code examples in docs against staging
+    name: Main branch test (Staging)
     runs-on: ubuntu-latest
 
     steps:
@@ -50,7 +50,7 @@ jobs:
         channel-id: C07V8NK09RC
 
   test-production:
-    name: Check code examples in docs against production
+    name: Production branch test
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs_on_pr.yml
+++ b/.github/workflows/docs_on_pr.yml
@@ -1,4 +1,4 @@
-name: Test Code Examples
+name: PR Test Code Examples
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Adding prefixes to differentiate actions

I find this slightly annoying:

![image](https://github.com/user-attachments/assets/18dcdef5-87f1-407d-b4ea-32c4f943c638)

And this:

![image](https://github.com/user-attachments/assets/bce95627-e5d5-41b8-b869-4886e8af7d1c)

