### PR TITLE
Fix heading case in product docs

### DIFF
--- a/docs/product/Extend and run tools/Browser based tools.md
+++ b/docs/product/Extend and run tools/Browser based tools.md
@@ -58,7 +58,7 @@ from portia.open_source_tools.browser_tool import BrowserTool
 
 task = "Find my connections called 'Bob' on LinkedIn (https://www.linkedin.com)"
 
-# Needs BrowserBase API Key and project_id
+# Needs BrowserBase API key and project_id
 portia = Portia(config=Config.from_default(),
                 tools=[BrowserTool()])
 ```
@@ -71,12 +71,12 @@ from portia.open_source_tools.browser_tool import BrowserToolForUrl
 
 task = "Find my connections called 'Bob' on LinkedIn"
 
-# Needs BrowserBase API Key and project_id
+# Needs BrowserBase API key and project_id
 portia = Portia(config=Config.from_default(),
                 tools=[BrowserToolForUrl("https://www.linkedin.com")])
 ```
 
-### A Simple E2E Example
+### A simple E2E example
 
 ```python title="Full example"
 from dotenv import load_dotenv

--- a/docs/product/Extend and run tools/MCP servers.md
+++ b/docs/product/Extend and run tools/MCP servers.md
@@ -6,7 +6,7 @@ slug: /mcp-servers
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Integrating an MCP Server
+# Integrating an MCP server
 
 The Model Context Protocol (MCP) makes it very easy to integrate third-party tools into your Portia AI project. To find out more you can visit the official MCP docs (<a href="https://modelcontextprotocol.io/" target="_blank">**↗**</a>). We offer the three methods currently available to interact with MCP servers:
 

--- a/docs/product/Get started/A tour of our SDK.md
+++ b/docs/product/Get started/A tour of our SDK.md
@@ -3,7 +3,7 @@ sidebar_position: 6
 slug: /getting-started-tour
 ---
 
-# A Tour of our SDK
+# A tour of our SDK
 
 Portia AI enables developers to build powerful, production-ready agents that can interact with real-world APIs, manage context intelligently, and even automate web browsers.
 This tutorial provides a whistlestop tour of the SDK to get you started.
@@ -193,7 +193,7 @@ Trying out the more complex example can show you how powerful autonomous agents 
 
 ---
 
-## 2. Tools, End Users, and LLMs
+## 2. Tools, end users, and LLMs
 
 **File**: [`2_tools_end_users_llms.py` ↗](https://github.com/portiaAI/portia-agent-examples/blob/main/getting-started/2_tools_end_users_llms.py)
 
@@ -367,7 +367,7 @@ print(portia.run(task).outputs.final_output)
 
 ---
 
-## 4. Browser Automation
+## 4. Browser automation
 
 **File**: [`4_browser_use.py` ↗](https://github.com/portiaAI/portia-agent-examples/blob/main/getting-started/4_browser_use.py)
 
@@ -471,7 +471,7 @@ with an even more complex and powerful use-case.
 
 ---
 
-## Summary Table
+## Summary table
 
 | Example File                | Focus             | Features Introduced                      |
 | --------------------------- | ----------------- | ---------------------------------------- |

--- a/docs/product/Get started/Manage config options.md
+++ b/docs/product/Get started/Manage config options.md
@@ -19,7 +19,7 @@ The `Config` class of your `Portia` instance allows you to:
 ## Configure LLM options
 The `Config` class (<a href="/SDK/portia/config" target="_blank">**SDK reference ↗**</a>) allows you to control various LLM and agent execution options.
 
-### LLM Provider
+### LLM provider
 
 Portia uses providers such as OpenAI and Anthropic for usage of generative AI models. You can configure the provider that Portia will use with the `llm_provider` config setting.
 
@@ -291,7 +291,7 @@ from portia import Config
 config = Config.from_default(default_model="openai/gpt-4.1", planning_model="anthropic/claude-3-5-sonnet")
 ```
 
-### Models for Tools
+### Models for tools
 
 A couple of the tools provided in the Portia SDK use generative models to complete tasks, specifically:
 

--- a/docs/product/Get started/install.md
+++ b/docs/product/Get started/install.md
@@ -136,7 +136,7 @@ Portia will return the final state of the plan run created in response to the su
 }
 ```
 
-### Test your installation from a python file
+### Test your installation from a Python file
 As a final verification step for your installation, set up the required environment variables in the `.env` of a project directory of your choice, namely the relevant LLM API keys. We can now replicate the CLI-driven test above from a python file within that directory.
 
 <Tabs groupId="llm-provider">

--- a/docs/product/Plan and run workflows/Generate a plan.md
+++ b/docs/product/Plan and run workflows/Generate a plan.md
@@ -176,7 +176,7 @@ plan = PlanBuilder(
 ).build() # build the plan once finalized
 
 ```
-## User Led Learning
+## User led learning
 
 Example plans can be used to bias the planner towards actions, tool use and behaviours, while also improving the planners ability to generate more complex plans. Broadly, the process for doing this with portia is 3 steps below
 
@@ -188,7 +188,7 @@ For a deep dive into this feature and a practical example, check out our <a href
 
 Now that you know how to generate plans in response to a user query, let's take a look at how to run a plan in the next section.
 
-## Structured Output Schema
+## Structured output schema
 
 For some plans you might want to have a structured output at the end of a plan, for this we allow the ability to attach a structured output schema to the plan that the summarizer agent will attempt to coerce the results to. This is optional. To use, attach to the Plan object, and any Plan Runs that are created from this will attempt to use structured output for the final result, this can pull information from any point of the plan steps and is not just the final step. To attach a schema, you can do it through the PlanBuilder or the Plan interfaces, as below.
 
@@ -205,7 +205,7 @@ from portia import (
 load_dotenv()
 portia = Portia(tools=example_tool_registry)
 
-# Final Output schema type to coerce to
+# Final output schema type to coerce to
 class FinalPlanOutput(BaseModel):
     result: float # result here is an integer output from calculator tool, but will be converted to a float via structured output
 

--- a/docs/product/Running in production/Manage end users.md
+++ b/docs/product/Running in production/Manage end users.md
@@ -26,7 +26,7 @@ The `EndUser` class can be used to represent your users within `Portia`.
 :::
 
 
-## End Users at Portia
+## End users at Portia
 
 In Production, you will be running plans for many stakeholders including customers, employees and partners. You may want to pass information specific to these individuals when they submit a prompt and / or information specific to the current context they are operating in (e.g. the particular app they are using when they submit their prompt to initiate a plan run).
 
@@ -96,7 +96,7 @@ The result of this code block will be the addition of an `end_user_id` within th
 ```
 
 
-## Accessing End Users in a tool
+## Accessing end users in a tool
 
 End User objects are passed through to the tool run function as part of the `ToolRunContext`. This allows you to access attributes for your users in tools.
 
@@ -128,7 +128,7 @@ class EndUserUpdateTool(Tool):
         return name
 ```
 
-## End User State Management
+## End user state management
 
 As we mentioned above End Users are first class citizens in the Portia Ecosystem. This means they are independent entities with their own state. Changes you make to them are persisted in storage and we refresh the state before commencing `plan_runs`. 
 
@@ -153,7 +153,7 @@ plan_run = portia.run(
 )
 ```
 
-## End User and OAuth tokens
+## End user and OAuth tokens
 
 If you are using Portia Cloud Tools which support user level OAuth tokens, these tokens are stored against the EndUser of the `plan_run`. If you have the setting enabled (see Security), tokens will be reused for each end user reducing the number of authentication flows they must do.
 This makes setting an `end_user` correctly important in this case to avoid token collision issues.

--- a/docs/product/Security/Security Overview.md
+++ b/docs/product/Security/Security Overview.md
@@ -6,7 +6,7 @@ slug: /security
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Portia Cloud Security
+# Portia cloud security
 
 Understanding the security of your agentic system is critical to deploying agents in production. Portia uses production-grade security and encryption and offers granular customization of security policies to ensure your data is secure within our systems. 
 

--- a/docs/product/Security/Security Overview.md
+++ b/docs/product/Security/Security Overview.md
@@ -26,7 +26,7 @@ Under the default policy, Portia will store the encrypted token until it expires
 
 This retention policy is best for usability as it minimizes the number of times users will need to go through the OAuth authentication flow. 
 
-### No Refresh
+### No refresh
 
 Under the No Refresh policy, Portia will store the encrypted tokens until they expire. However no refresh tokens will be stored. 
 

--- a/docs/product/Telemetry/Telemetry Overview.md
+++ b/docs/product/Telemetry/Telemetry Overview.md
@@ -14,7 +14,7 @@ We use **PostHog** for telemetry collection. The data is completely anonymized a
 
 We track the following events.
 
-### Portia Function Calls
+### Portia function calls
 We track the following Portia function calls:
 - `Portia.run`
 - `Portia.plan`
@@ -38,7 +38,7 @@ self.telemetry.capture(PortiaFunctionCallTelemetryEvent(
 ))
 ```
 
-### Portia Tool Calls
+### Portia tool calls
 We also track when a tool call happens and the name of the tool that was executed. None of the arguments to the tool are tracked.
 
 # Opting out


### PR DESCRIPTION
## Summary
- update capitalization in docs/product headings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_6842b7ed843c8329bba277127b439a98