### PR TITLE
Fix typo with variable names and add back ticks

### DIFF
--- a/docs/product/Plan and run workflows/Generate a plan.md
+++ b/docs/product/Plan and run workflows/Generate a plan.md
@@ -4,16 +4,18 @@ slug: /generate-plan
 ---
 
 # Generate a plan
+
 Learn how to create structured, multi-agent plans using your LLM of choice and familiarise yourself with the structure of plans created using Portia.
 :::tip[TL;DR]
+
 - A plan is the set of steps an LLM thinks it should take in order to respond to a user prompt.
-- A plan is represented by the `Plan` class and can be generated from a user prompt using the `plan` method of the `Portia` class (<a href="/SDK/portia/portia" target="_blank">**SDK reference ↗**</a>).
-    - Portia uses optimised system prompts and structured outputs to ensure adherence to a plan.
-    - You can create your own plans manually or reload existing plans, which is especially useful for repeatable plan runs.
-:::
+- A plan is represented by the `Plan` class and can be generated from a user prompt using the `plan` method of the `Portia` class (<a href="/SDK/portia/portia" target="_blank">**SDK reference ↗**</a>). - Portia uses optimised system prompts and structured outputs to ensure adherence to a plan. - You can create your own plans manually or reload existing plans, which is especially useful for repeatable plan runs.
+  :::
 
 ## Overview of plans in Portia
+
 A plan is the set of steps an LLM thinks it should take in order to respond to a user prompt. Plans are:
+
 - **Immutable**: Once a plan is generated, it cannot be altered. This is important for auditability.
 - **Structured**: We use optimised system prompts to guide the LLM along a simple design language when generating a plan. This makes the plan format predictable and easy to process for the purposes of automation.
 - **Human-readable**: Our planning language is in a simple, serialisable format. It is easy to render and present to users in a human readable front-end experience. This helps your users easily stay on top of your LLM's reasoning.
@@ -21,7 +23,9 @@ A plan is the set of steps an LLM thinks it should take in order to respond to a
 While Portia generates a plan in response to a user prompt and then runs it, you also have the option to create plans yourself manually. This is especially suitable for your users' more repeatable routines.
 
 ## Introducing a Plan
+
 Let's bring this one to life by looking at an example plan below, created in response to the query `Search for the latest SpaceX news from the past 48 hours and if there are at least 3 articles, email Avrana (avrana@kern.ai) a summary of the top 3 developments with subject 'Latest SpaceX Updates'`.
+
 ```json title="plan.json"
 {
   "steps": [
@@ -29,7 +33,7 @@ Let's bring this one to life by looking at an example plan below, created in res
       "task": "Search for the latest SpaceX news from the past 48 hours using the search tool.",
       "inputs": [],
       "tool_id": "search_tool",
-      "output": "$spacex_news_results",
+      "output": "$spacex_news_results"
     },
     {
       "task": "Summarize the top 3 developments from the SpaceX news articles.",
@@ -59,18 +63,20 @@ Let's bring this one to life by looking at an example plan below, created in res
 }
 ```
 
-A plan includes a series of steps defined by 
+A plan includes a series of steps defined by
+
 - `"task"` A task describing the objective of that particular step.
 - `"input"` The inputs required to achieve the step. Notice how the LLM is guided to weave the outputs of previous steps as inputs to the next ones where applicable e.g. `$spacex_news_results` coming out of the first step acts as an input to the second one.
-- `"tool_id"` Any relevant tool needed for the completion of the step. Portia is able to filter for the relevant tools during the multi-shot plan generation process. As we will see later on in this tutorial you can specify the tool registries (directories) you want when handling a user prompt, including local / custom tools and ones provided by third parties. In this example we are referencing tools from Portia's cloud-hosted library, prefixed with `portia:`. 
+- `"tool_id"` Any relevant tool needed for the completion of the step. Portia is able to filter for the relevant tools during the multi-shot plan generation process. As we will see later on in this tutorial you can specify the tool registries (directories) you want when handling a user prompt, including local / custom tools and ones provided by third parties. In this example we are referencing tools from Portia's cloud-hosted library, prefixed with `portia:`.
 - `"output"` The step's final output. As mentioned above, every step output can be referenced in future steps. As we will see shortly, these outputs are serialised and saved in plan run state as it is being executed.
 - `"condition"` An optional condition that's used to control the execution of the step. If the condition is not met, the step will be skipped. This condition will be evaluated by our introspection agent, with the context of the plan and plan run state.
 
-
 ## Create a plan from a user prompt
+
 When responding to a user's prompt with Portia, you can either chain the plan generation process to the subsequent instantiation of a plan run from it, or you can choose to decouple them. The latter option allows you for example to display the plan to the user and tweak it before running a plan.
 
 Let's look at how we generate a plan from a user prompt. Paste the code below into your project and run it:
+
 ```python title="main.py"
 from dotenv import load_dotenv
 from portia import (
@@ -92,16 +98,13 @@ print(plan.model_dump_json(indent=2))
 ```
 
 As mentioned earlier in the documentation, the `Portia` instance class is your main entrypoint to interact with Portia's libraries (<a href="/SDK/portia/" target="_blank">**SDK reference ↗**</a>). The `plan` method is available from the `Portia` instance class and allows you to generate a plan from the query. Running the `plan` method per the code above returns a `Plan` object (<a href="/SDK/portia/plan" target="_blank">**SDK reference ↗**</a>) which looks as follows:
+
 ```json title="plan.json"
 {
   "id": "plan-1dcd74a4-0af5-490a-a7d0-0df4fd983977",
   "plan_context": {
     "query": "Which stock price grew faster, Amazon or Google?",
-    "tool_ids": [
-      "calculator_tool",
-      "weather_tool",
-      "search_tool"
-    ]
+    "tool_ids": ["calculator_tool", "weather_tool", "search_tool"]
   },
   "steps": [
     {
@@ -138,15 +141,18 @@ As mentioned earlier in the documentation, the `Portia` instance class is your m
 ```
 
 The `plan` method can take the following additional parameters:
+
 - `tools` in order to confine the plan generation to a narrower set of tools if required (for simplicity or for user-access considerations). In our example above we provided the `example_tool_registry`, which is a collection of three open source tools in our SDK.
 - `example_plans` expects a list of `Plan` objects. This allows you to use existing plans as inspiration or templates, which improves repeatability for more routine plan runs.
 
 ## Build a plan manually
+
 If you prefer to explicitly define a plan step by step rather than rely our planning agent, e.g. for established processes in your business, you can use the PlanBuilder interface. This obviously implies outlining all the steps, inputs, outputs and tools.
 
 The `PlanBuilder` offers methods to create each part of the plan iteratively
-- `.step` method adds a step to the end of the plan. It takes a task, toold and output name as argument
-- `.input` and `.condition` methods add to the last step added, but can be overwritten with a step_index variable, and map outputs from one step to inputs of chosen (default last step), or considerations
+
+- `.step` method adds a step to the end of the plan. It takes a `task`, `tool_id` and `output` name as arguments.
+- `.input` and `.condition` methods add to the last step added, but can be overwritten with a `step_index` variable, and map outputs from one step to inputs of chosen (default last step), or considerations
 - `.build` finally builds the `Plan` objective
 
 ```python title='plan_builder.py'
@@ -176,6 +182,7 @@ plan = PlanBuilder(
 ).build() # build the plan once finalized
 
 ```
+
 ## User led learning
 
 Example plans can be used to bias the planner towards actions, tool use and behaviours, while also improving the planners ability to generate more complex plans. Broadly, the process for doing this with portia is 3 steps below
@@ -217,6 +224,7 @@ plan = PlanBuilder(
 ).build()
 
 # Example via plan interface
-plan2 = portia.plan("Add 1 + 1", structured_output_schema=FinalPlanOutput) 
+plan2 = portia.plan("Add 1 + 1", structured_output_schema=FinalPlanOutput)
 ```
-Run the plan as normal and the final output will be an instance of the attached schema. 
+
+Run the plan as normal and the final output will be an instance of the attached schema.


### PR DESCRIPTION
The generate plan page had a typo of "toold" and hadn't formatted the variable names as code. I've corrected this now. The changes I made are on lines 153 - 155 in this file. Github seems to have read in other changes with line breaks but I didn't change anything on those lines. 
<img width="827" alt="Screenshot 2025-06-19 at 15 53 23" src="https://github.com/user-attachments/assets/fe562c76-f5e2-4b10-b7be-0e2d4b6c903f" />
